### PR TITLE
Fix stacking of all trials, add metadata stacking

### DIFF
--- a/src/ca_utils/io/session.py
+++ b/src/ca_utils/io/session.py
@@ -166,7 +166,6 @@ class Session:
         else:
             stack, frame_times = self._single_trial_stack(trial_number)
             metadata = self.log.loc[trial_number].to_dict()
-            metadata["stim_info"] = self.stim_info(trial_number=trial_number)
         stack = self._reshape(stack, split_channels, split_volumes, force_dims, use_zarr)
 
         # volume times correspond to the time of the first frame for each volume
@@ -185,6 +184,8 @@ class Session:
             },
             attrs=metadata,
         )
+        # Add infos about the stimuli to the dataset attributes (works for single trials and all trials)
+        stack.attrs["stim_info"] = self.stim_info(trial=stack)
 
         return stack
 


### PR DESCRIPTION
- Fixed check for at least two complete volumes in last trial
- Added stacking of metadata for all trials, field from log are either combined or stacked to arrays where possible
- Changed last frame to collect so that no frames after offset of last trial are included
- Changed stacking of frame_times across trials to create a continuous time vector across trials